### PR TITLE
fix thresholding in CircClust

### DIFF
--- a/CircClust.m
+++ b/CircClust.m
@@ -1,0 +1,128 @@
+function out = CircClust(theta, target, low_p, up_p)
+
+% CircClust performs clustering on circular data using the empirical,
+% angle-specific clustering thresholds provided.
+%
+% Use as:
+%   [out] = CircClust(theta, target, low_p, up_p)
+%
+%
+% Input arguments:
+%   theta      = a vector of angles (in radians), representing the phase of the target values
+%   target     = a vector of target values corresponding to the theta values (data points to be clustered)
+%   low_p      = vector of lower empirical, angle-specific threshold boundaries 
+%   up_p       = vector of upper empirical, angle-specific threshold boundaries
+%
+% Output:
+%   out                 = structure containing the following fields:
+%    .up_clusts_idxs    = indices of clusters above the upper empirical thresholds
+%    .low_clusts_idxs   = indices of clusters below the lower empirical thresholds
+%    .up_cluststats     = sum of target values for each cluster above the upper threshold
+%    .low_cluststats    = sum of target values for each cluster below the lower threshold
+%
+% Copyright (C) 2025, Elio Balestrieri & Teresa Berther, University of Münster, Germany 
+
+% check input
+if any(isnan(theta)) || any(isnan(target))
+    error('Data contains NaN values. Remove NaNs before clustering.');
+end
+if any(theta < -pi) || any(theta > 2*pi)
+    error('Phase values for clustering are outside the expected range (-π to π or 0 to 2π). Use phase values in radians.');
+end
+
+% classify points below and above the thresholds
+below_ptile = target < low_p;
+low_clusts = localClust(below_ptile, theta);
+
+above_ptile = target > up_p;
+up_clusts = localClust(above_ptile, theta);
+
+% compute statistics for clusters above the upper threshold
+up_cluststats = nan(size(up_clusts)); 
+acc_clust = 1;
+for iclust = up_clusts
+    up_cluststats(acc_clust) = sum(target(iclust{:}));
+    acc_clust = acc_clust + 1;
+end
+
+% compute statistics for clusters below the lower threshold
+low_cluststats = nan(size(low_clusts)); 
+acc_clust = 1;
+for iclust = low_clusts
+    low_cluststats(acc_clust) = sum(target(iclust{:}));
+    acc_clust = acc_clust + 1;
+end
+
+% output structure with clustering results
+out.up_clusts_idxs = up_clusts;
+out.low_clusts_idxs = low_clusts;
+out.up_cluststats = up_cluststats;
+out.low_cluststats = low_cluststats;
+
+end
+
+
+
+
+function clusts = localClust(masklength, anglevect)
+
+% localClust performs local clustering based on angular distances 
+% between points, given a mask and an angle vector. It finds clusters 
+% of contiguous points with similar angular distances.
+%
+% Use as:
+%   [clusts] = localClust(masklength, anglevect)
+%
+%
+% Input arguments:
+%   masklength = binary vector or logical mask where 'true' indicates points to be considered for clustering
+%   anglevect  = vector of angular data corresponding to the mask
+%
+% Output:
+%   clusts     = cell array of clusters, each cell contains the indices of the points belonging to this cluster
+%
+% Copyright (C) 2025, Elio Balestrieri & Teresa Berther, University of Münster, Germany 
+
+
+if ~any(masklength)
+    clusts = {}; % return empty if no points are selected
+else
+    % convert the mask into a complex representation using angles
+    cmplx_repr = masklength .* exp(anglevect * 1i);
+    
+    % compute pairwise distances between all points
+    [X, Y] = meshgrid(cmplx_repr);
+    dists = round(abs(X - Y), 5);  % calculate distance and round to 5 decimals
+    minsigdist = unique(dists);    % find unique distances
+    
+    % identify the smallest non-zero distance to form clusters
+    shortlenarc = dists == minsigdist(2);
+    [row, col] = find(shortlenarc);  % find rows and columns of minimum distance
+    
+    % initialize cluster accumulation
+    acc = 1; 
+    clusts = {};
+    
+    while ~isempty(col)
+        % accumulate points that belong to the same cluster
+        idxs_acc = [];
+        seed_entry = col(1); 
+        while true
+            idxs_acc = [idxs_acc; seed_entry]; 
+            tmp_mask = ismember(col, seed_entry);
+            
+            if ~any(tmp_mask)
+                break
+            else
+                seed_entry = unique(row(tmp_mask));
+                row(tmp_mask) = [];
+                col(tmp_mask) = [];
+            end
+        end
+    
+        clusts{acc} = unique(idxs_acc);
+        acc = acc + 1;
+    end
+end
+
+end

--- a/CircPerm.m
+++ b/CircPerm.m
@@ -1,0 +1,135 @@
+function [summary, bounds] = CircPerm(EMPdat, PERMdat, theta, alternative)
+
+% CircPerm performs a cluster permutation test on circular data.
+%
+%
+% Use as:
+%   [summary, bounds] = CircPerm(EMPdat, PERMdat, theta, 'two_sided')
+%
+%
+% Input arguments:
+%   EMPdat      = vector of empirical data across phase bins to be tested 
+%   PERMdat     = phase bins x permutation iterations matrix of surrogate data
+%   theta       = a vector of angles (in radians) from -pi to pi/0 to 2*pi, representing the phase bins of the data (phase bins x 1)
+%   alternative = string specifying alternative hypothesis, "two_sided", "greater" or "less" (default = "two_sided")
+%
+% Output:
+%   summary            = structure containing the following fields:
+%     .idxs            = indices of the phase bins for each cluster, each row represents a separate cluster 
+%     .clustmass_stat  = clustering statistic (i.e. sum of z-scores) for each cluster
+%     .p_ecdf          = empirical cumulative distribution value for each cluster statistic (proportion of surrogate statistics <= observed value)
+%     .p               = permutation p-value (proportion of absolute surrogate stats values >= observed values)
+%   
+%   bounds             = empirical boundaries used for clustering in each bin, based on ecdf distribution
+%
+% Copyright (C) 2025, Elio Balestrieri & Teresa Berther, University of Münster, Germany 
+
+% check input
+if size(theta, 1) == 1
+    theta = theta';
+    warning('Given angle/phase bin vector did not match required dimensions, was transposed automatically - check input.')
+end 
+if any(isnan(EMPdat), 'all') || any(isnan(PERMdat), 'all')
+    error('Data contains NaN values. Remove NaNs before performing the cluster permutation test.');
+end
+if any(theta < -pi) || any(theta > 2*pi)
+    error('Phase values are outside the expected range (-π to π or π to 2π). Use phase values in radians and scale to expected range.');
+end
+if length(EMPdat) ~= length(theta)
+    error('Dimension mismatch in empirical data: expected input is a vector of empirical data across the given phase bins.');
+end
+if size(PERMdat, 1) ~= length(theta)
+    error('Dimension mismatch in surrogate data: expected input is a matrix of size phase bins x perm iterations.');
+end
+
+% set boundaries for cluster definition according to alternative hypothesis
+if nargin < 4 || isempty(alternative) || strcmp(alternative, "two_sided")
+    low_p = 0.025;
+    up_p = 0.975;
+elseif strcmp(alternative, "greater")
+    low_p = 0;
+    up_p = 0.95;
+elseif strcmp(alternative, "lesser")
+    low_p = 0.05;
+    up_p = 1;
+end 
+
+
+% config
+PERMEMPdat = [PERMdat, EMPdat]; 
+nbins = length(theta); 
+nperms = size(PERMdat, 2);
+
+% find empirical boundaries
+[up_bounds, low_bounds] = deal(nan(nbins, 1));
+
+for ibin = 1:nbins
+
+    this_bin = PERMEMPdat(ibin, :);
+    [ECDF, val] = ecdf(this_bin);
+    tmp_low = val(ECDF <= low_p);
+    low_bounds(ibin) = tmp_low(end);
+    tmp_up = val(ECDF >= up_p);
+    up_bounds(ibin) = tmp_up(1);
+
+end
+
+%%% perform the permutations using surrogate data
+surrogatedist = nan(nperms, 1); % store maximum clustering statistics from each permutation
+for iperm = 1:nperms
+    
+    % select current permutation
+    thisperm = PERMEMPdat(:, iperm);
+    
+    % cluster the permuted data
+    tmp_out = CircClust(theta, thisperm, low_bounds, up_bounds);
+    
+    % combine the clustering statistics from both low and high clusters
+    all_cluststats = [tmp_out.low_cluststats, tmp_out.up_cluststats];
+
+    % select the maximum clustering statistic (by absolute value)
+    if ~isempty(all_cluststats)
+        [~, maxabs_idx] = max(abs(all_cluststats));
+        surr_val = all_cluststats(maxabs_idx);
+    else
+        % in case there are no valid clusters, use the max absolute value
+        [~, maxabs_idx] = max(abs(thisperm));
+        surr_val = thisperm(maxabs_idx);
+    end
+
+    % store the surrogate statistic
+    surrogatedist(iperm) = surr_val;
+end
+
+
+%%% clustering statistic for actual data
+actual_avg = EMPdat;
+out = CircClust(theta, actual_avg, low_bounds, up_bounds);
+
+% combine the clustering statistics from both low and high clusters
+all_cluststats = [out.low_cluststats, out.up_cluststats];
+all_clustidxs = [out.low_clusts_idxs, out.up_clusts_idxs];
+
+
+%%% compute p-values for each cluster by comparing with surrogate statistics
+summary = struct('idxs', {}, 'clustmass_stat', [], 'p_ecdf', [], 'p', []);
+acc = 1;
+for imassstat = all_cluststats
+
+    % combine surrogate & actual clustering statistic +inf to always have at least one value above the cluster stat  
+    tmpstats = [surrogatedist; imassstat; inf]; 
+    % compute the p-value as the proportion of surrogate statistics less than or equal to the actual statistic
+    p_ecdf = mean(tmpstats <= imassstat);
+    p = mean(abs(surrogatedist) >= abs(imassstat)); 
+
+    summary(acc).idxs = all_clustidxs(acc);
+    summary(acc).clustmass_stat = imassstat;
+    summary(acc).p_ecdf = p_ecdf;
+    summary(acc).p = p;
+    
+    acc = acc + 1;
+end
+
+bounds = [low_bounds, up_bounds];
+
+end


### PR DESCRIPTION
### Threshold fix 
- remove 'threshtype' parameter in CircClust function to streamline code and remove non-working thresholding type options 
- change the empirical thresholding to be bin/angle-specific instead of using the more conservative min and max of boundary values across bins/angles 
- adapt CircClust documentation accordingly 
- use correct function calls for CircClust in CircPerm 